### PR TITLE
chore: update test matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x]
+        node-version: [16.x, 18.x, 19.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "music-routes-search": "^2.2.1"
   },
   "engines": {
-    "node": ">=12.x"
+    "node": ">=16.x"
   },
   "devDependencies": {
     "standard": "^17.0.0"


### PR DESCRIPTION
BREAKING CHANGE: drop support for EOL Node.js 14.x